### PR TITLE
Fixed permission error

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func addToZip(zipPath string, name string, source *os.File) {
 	defer os.RemoveAll(manifestDir)
 
 	tmpPath := path.Join(manifestDir, name)
-	os.MkdirAll(path.Dir(tmpPath), 0600)
+	os.MkdirAll(path.Dir(tmpPath), 0700)
 	f, err := os.Create(tmpPath)
 	if err != nil {
 		log.Fatalln("Failed opening file:", err)


### PR DESCRIPTION
Using 600 causes an error when signing AAB files in macOS Ventura. I changed to 700