### PR TITLE
tmpDir changed from hardcoded to crossplatform os.TempDir()

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,11 +18,12 @@ import (
 )
 
 const (
-	tmpDir          = "/tmp"
 	namespace       = "http://schemas.android.com/apk/res/android"
 	versionCodeAttr = "versionCode"
 	versionNameAttr = "versionName"
 )
+
+var tmpDir = os.TempDir()
 
 type Config struct {
 	versionCode int32


### PR DESCRIPTION
Fix that allows you to use the application on Windows.